### PR TITLE
Feat gitignore dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Git
+.git
+.gitignore
+
+# Entornos virtuales
+venv/
+env/
+.venv/
+
+# Python cache
+__pycache__
+*.pyc
+*.pyo
+
+# Variables de entorno (se pasan en runtime)
+.env
+
+# Este archivo
+.dockerignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Entornos virtuales
+venv/
+env/
+.venv/
+
+# Cachés de Python
+__pycache__/
+*.pyc
+*.pyo
+
+# Base de datos local
+*.db
+*.sqlite
+*.sqlite3
+
+# Variables de entorno
+.env


### PR DESCRIPTION
- .gitignore: excluye entornos virtuales, cachés Python, bases de datos locales y .env
- .dockerignore: excluye git, entornos virtuales, cachés Python, .env y el propio .dockerignore
- Versiones mínimas para mantener repo e imágenes limpias

Closes #26 