### PR TITLE
feat: agregar configuración dinámica de estrategias (fees y riesgo)

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -26,9 +26,17 @@ from app.domain.exceptions import (
     InvalidStatusTransition,
     DuplicateEmailError,
 )
+from app.services.configuration_service import ConfigurationService 
+
+_config_service = ConfigurationService()
 
 
-def get_facade(session: Session = Depends(get_db)) -> BankingFacade:
+def get_config_service() -> ConfigurationService:
+    """Dependency para obtener el servicio de configuración (siempre la misma instancia)"""
+    return _config_service
+
+def get_facade(session: Session = Depends(get_db),
+               config_service: ConfigurationService = Depends(get_config_service)) -> BankingFacade:
     """Construye BankingFacade con repos SQL y servicios (fee/risk por defecto)."""
     customer_repo = SQLCustomerRepository(session)
     account_repo = SQLAccountRepository(session)
@@ -67,6 +75,7 @@ def get_facade(session: Session = Depends(get_db)) -> BankingFacade:
         transfer_service=transfer_service,
         deposit_service=deposit_service,
         withdraw_service=withdraw_service,
+        config_service=config_service,  
     )
 
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -18,6 +18,39 @@ from app.schemas.dto import (
 router = APIRouter()
 
 
+# ENDPOINTS DE CONFIGURACIÓN (NUEVOS)
+@router.get("/config/strategies", tags=["configuración"])
+def get_strategies(
+    facade: BankingFacade = Depends(get_facade),
+):
+    try:
+        return facade.get_config()
+    except Exception as e:
+        raise to_http(e)
+
+@router.post("/config/strategies/fee", tags=["configuración"])
+def set_fee_strategy(
+    fee_type: str,
+    facade: BankingFacade = Depends(get_facade),
+):
+    try:
+        facade.set_fee_strategy(fee_type)
+        return facade.get_config()
+    except Exception as e:
+        raise to_http(e)
+
+
+@router.post("/config/strategies/risk/{rule_name}", tags=["configuración"])
+def set_risk_rule(
+    rule_name: str,
+    enabled: bool,
+    facade: BankingFacade = Depends(get_facade),
+):
+    try:
+        facade.set_risk_rule(rule_name, enabled)
+        return facade.get_config()
+    except Exception as e:
+        raise to_http(e)
 # ---------- Customers ----------
 
 @router.post(

--- a/app/application/facade.py
+++ b/app/application/facade.py
@@ -1,10 +1,11 @@
 from decimal import Decimal
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from app.domain.entities import Customer, Account, Transaction
 from app.domain.exceptions import ValidationError, NotFoundError
 from app.repositories.base import CustomerRepository, AccountRepository, TransactionRepository
 
+from app.services.configuration_service import ConfigurationService
 from app.services.transfer_service import TransferService
 from app.services.deposit_service import DepositService
 from app.services.withdraw_service import WithdrawService
@@ -17,7 +18,8 @@ class BankingFacade:
         transaction_repo: TransactionRepository,
         transfer_service: TransferService,
         deposit_service: DepositService, 
-        withdraw_service: WithdrawService 
+        withdraw_service: WithdrawService,
+        config_service: ConfigurationService,
     ):
         self.customer_repo = customer_repo
         self.account_repo = account_repo
@@ -25,6 +27,8 @@ class BankingFacade:
         self.transfer_service = transfer_service
         self.deposit_service = deposit_service
         self.withdraw_service = withdraw_service
+        self.config_service = config_service
+
 
     def create_customer(self, name: str, email: str) -> Customer:
         customer = Customer(name=name, email=email)
@@ -65,3 +69,15 @@ class BankingFacade:
         transactions = self.transaction_repo.list_by_account(account_id)
 
         return transactions[offset : offset + limit]
+    
+    def get_config(self) -> Dict[str, Any]:
+        """Retorna la configuración actual"""
+        return self.config_service.get_full_config()
+    
+    def set_fee_strategy(self, fee_type: str) -> None:
+        """Cambia la estrategia de comisiones"""
+        self.config_service.set_fee_strategy(fee_type)
+    
+    def set_risk_rule(self, rule_name: str, enabled: bool) -> None:
+        """Activa/desactiva una regla de riesgo"""
+        self.config_service.set_risk_rule(rule_name, enabled)

--- a/app/services/configuration_service.py
+++ b/app/services/configuration_service.py
@@ -1,0 +1,97 @@
+from decimal import Decimal
+from typing import Dict, Any
+
+from app.services.fee_strategies import (
+    FeeStrategy,
+    NoFeeStrategy,
+    FlatFeeStrategy,
+    PercentFeeStrategy,
+    TieredFeeStrategy
+)
+from app.services.risk_strategies import (
+    MaxAmountRule,
+    VelocityRule,
+    DailyLimitRule
+)
+
+
+class ConfigurationService:
+    """Servicio que mantiene la configuración actual de estrategias en memoria.
+    
+    Guarda qué estrategia de fee está activa y qué reglas de riesgo están habilitadas.
+    Los valores de las estrategias son fijos (no configurables individualmente).
+    """
+    
+    def __init__(self):
+        # Configuración por defecto
+        self._fee_type = "flat"  # "no", "flat", "percent", "tiered"
+        
+        self._risk_rules = {
+            "max_amount": True,
+            "velocity": True,
+            "daily_limit": True
+        }
+    
+    # ============================================
+    # MÉTODOS PARA FEE STRATEGY
+    # ============================================
+    
+    def get_current_fee_strategy(self) -> FeeStrategy:
+        """Retorna la instancia de FeeStrategy según la configuración actual"""
+        if self._fee_type == "flat":
+            return FlatFeeStrategy()
+        elif self._fee_type == "percent":
+            return PercentFeeStrategy()
+        elif self._fee_type == "tiered":
+            return TieredFeeStrategy()
+        else:  # "no" o cualquier otro
+            return NoFeeStrategy()
+    
+    def set_fee_strategy(self, fee_type: str) -> None:
+        """Cambia la estrategia de fee activa"""
+        valid_types = ["no", "flat", "percent", "tiered"]
+        if fee_type in valid_types:
+            self._fee_type = fee_type
+    
+    def get_current_fee_type(self) -> str:
+        """Retorna el tipo de fee actual (para el frontend)"""
+        return self._fee_type
+    
+    # ============================================
+    # MÉTODOS PARA RISK STRATEGIES
+    # ============================================
+    
+    def get_current_risk_strategies(self) -> list:
+        """Retorna la lista de reglas de riesgo activas"""
+        strategies = []
+        
+        if self._risk_rules["max_amount"]:
+            strategies.append(MaxAmountRule())
+        
+        if self._risk_rules["velocity"]:
+            strategies.append(VelocityRule())
+        
+        if self._risk_rules["daily_limit"]:
+            strategies.append(DailyLimitRule())
+        
+        return strategies
+    
+    def set_risk_rule(self, rule_name: str, enabled: bool) -> None:
+        """Activa o desactiva una regla de riesgo específica"""
+        if rule_name in self._risk_rules:
+            self._risk_rules[rule_name] = enabled
+    
+    def get_risk_rules_status(self) -> Dict[str, bool]:
+        """Retorna el estado de activación de cada regla de riesgo"""
+        return self._risk_rules.copy()
+    
+    # ============================================
+    # MÉTODOS PARA OBTENER CONFIGURACIÓN COMPLETA
+    # ============================================
+    
+    def get_full_config(self) -> Dict[str, Any]:
+        """Retorna toda la configuración actual (para el frontend)"""
+        return {
+            "fee": self._fee_type,
+            "risk": self._risk_rules.copy()
+        }


### PR DESCRIPTION
- Crea ConfigurationService para manejar configuración en memoria
- Modifica BankingFacade para exponer métodos de configuración
- Actualiza deps.py para inyectar ConfigurationService
- Agrega endpoints en routes.py para obtener y cambiar configuración

Las estrategias de fee (no, flat, percent, tiered) y reglas de riesgo (max_amount, velocity, daily_limit) ahora son configurables desde el frontend sin reiniciar el servidor. Los cambios se aplican a todas las transacciones futuras.

Closes #61